### PR TITLE
Added Env. Variables Support for DB and Engine Pointing + effective JSON marshalling without escapes + seed data capability

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -434,22 +434,6 @@ func getWordList(reader io.Reader) ([]string, error) {
 	return stringset.Deduplicate(words), nil
 }
 
-// func (c *Config) MarshalJSON() ([]byte, error) {
-// 	type Alias Config
-// 	b, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(c)})
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	// Replace escaped characters
-// 	s := string(b)
-// 	s = strings.Replace(s, "\\u0026", "&", -1) // Replace escaped &
-// 	s = strings.Replace(s, "\\u003c", "<", -1) // Replace escaped <
-// 	s = strings.Replace(s, "\\u003e", ">", -1) // Replace escaped >
-
-// 	return []byte(s), nil
-
-// }
-
 func (c *Config) JSON() ([]byte, error) {
 	type Alias Config
 	buffer := &bytes.Buffer{}

--- a/config/engineapi_test.go
+++ b/config/engineapi_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,4 +91,43 @@ func TestLoadEngineURI_MissingScheme(t *testing.T) {
 
 	err := c.loadEngineSettings(c)
 	assert.Error(t, err, "loadEngineSettings should return an error for missing scheme in URI")
+}
+func TestLoadEngineEnvSettings_ValidEnvSettings(t *testing.T) {
+	c := NewConfig()
+
+	// Set the required environment variables
+	os.Setenv(engineHost, "127.0.0.1")
+	os.Setenv(engineUser, "username")
+	os.Setenv(enginePass, "password")
+	os.Setenv(engineScheme, "http")
+	os.Setenv(enginePort, "80")
+	os.Setenv(enginePath, "path")
+
+	err := c.LoadEngineEnvSettings()
+	assert.NoError(t, err, "LoadEngineEnvSettings should not return an error with valid environment settings")
+	assert.NotNil(t, c.EngineAPI, "EngineAPI should not be nil after loading environment settings")
+
+	// Verify the loaded EngineAPI values
+	assert.Equal(t, "http", c.EngineAPI.Scheme, "Scheme should be 'http'")
+	assert.Equal(t, "username", c.EngineAPI.Username, "Username should be 'username'")
+	assert.Equal(t, "password", c.EngineAPI.Password, "Password should be 'password'")
+	assert.Equal(t, "127.0.0.1", c.EngineAPI.Host, "Host should be '127.0.0.1'")
+	assert.Equal(t, "80", c.EngineAPI.Port, "Port should be '80'")
+	assert.Equal(t, "path", c.EngineAPI.Path, "Path should be 'path'")
+}
+
+func TestLoadEngineEnvSettings_MissingEnvSettings(t *testing.T) {
+	c := NewConfig()
+
+	// Unset the required environment variables
+	os.Unsetenv(engineHost)
+	os.Unsetenv(engineUser)
+	os.Unsetenv(enginePass)
+	os.Unsetenv(engineScheme)
+	os.Unsetenv(enginePort)
+	os.Unsetenv(enginePath)
+
+	err := c.LoadEngineEnvSettings()
+	assert.Error(t, err, "LoadEngineEnvSettings should return an error with missing environment settings")
+	assert.Nil(t, c.EngineAPI, "EngineAPI should be nil if environment settings are missing")
 }

--- a/config/graphdb.go
+++ b/config/graphdb.go
@@ -57,38 +57,6 @@ func (c *Config) loadDatabaseSettings(cfg *Config) error {
 	return nil
 }
 
-// func (c *Config) LoadDatabaseEnvSettings() error {
-// 	dbURI := ""
-// 	if u, set := os.LookupEnv(amassUser); set {
-// 		u = u + "@"
-// 		p := ""
-// 		if penv, set := os.LookupEnv(amassPass); set {
-// 			p = ":" + penv + "@"
-// 		}
-// 		db := "localhost"
-// 		if dbEnv, set := os.LookupEnv(assetDB); set {
-// 			db = dbEnv
-// 		}
-// 		port := "5432"
-// 		if pEnv, set := os.LookupEnv(assetPort); set {
-// 			port = pEnv
-// 		}
-// 		n := "assetdb"
-// 		if nEnv, set := os.LookupEnv(assetDBName); set {
-// 			n = nEnv
-// 		}
-// 		if p != "" {
-// 			u = u[:len(u)-1]
-// 		}
-// 		dbURI = "postgres://" + u + p + db + ":" + port + "/" + n
-// 	}
-// 	if dbURI == "" {
-// 		return fmt.Errorf("no database URI found in environment variables")
-// 	}
-
-// 	return c.loadDatabase(dbURI)
-// }
-
 func (c *Config) LoadDatabaseEnvSettings() error {
 	dbURI := ""
 	if p, set := os.LookupEnv(amassPass); set {

--- a/config/graphdb.go
+++ b/config/graphdb.go
@@ -38,7 +38,6 @@ func (c *Config) loadDatabaseSettings(cfg *Config) error {
 	}
 
 	dbURIInterface, ok := c.Options["database"]
-	fmt.Println("loading database settings")
 	if !ok {
 		fmt.Println("loading env settings")
 		c.LoadDatabaseEnvSettings()

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,6 +1,20 @@
 # The scope objects can be used as seed data and obviously values to determine the scope of the engine.
 # The options are items that I believe we can implement as well (Obviously not now but later in the future)
 
+seed:
+  domains: # domain names to be used as seed data
+    - seed.com
+  ips: # IP addresses to be used as seed data
+    - 10.1.2.45
+    - 10.1.2.46-50
+    - 10.1.2.50-10.1.2.65
+  asns: # ASNs that are to be used as seed data
+    - 2468
+  cidrs: # CIDR ranges that are to be used as seed data
+    - 123.2.3.0/24
+  ports: # ports to be used when actively reaching a service
+    - 8080
+    - 8443
 scope:
   domains: # domain names to be in scope
     - example.com


### PR DESCRIPTION
This PR adds the following:

Environment variables for the DB and Engine to point to.

specifically:
lines `28-36` in `engineapi.go`
lines `27-34` in `graphdb.go`

will list the env variable names

Also added a custom method to marshal JSON without escaping special characters, this will solve problems with complex passwords.

Specifically, lines `437-449` in `config.go`

**THE ENGINE MUST CALL THIS METHOD, MAKE NECESSARY CHANGES TO THE ENGINE, SPECIFICALLY LINE 67 IN `client.go`**
![image](https://github.com/owasp-amass/config/assets/83852285/c7809bc6-d098-4108-a078-45665fecd6a8)
